### PR TITLE
Changed a URL to relative.

### DIFF
--- a/src/web/frontend/src/common/config.js
+++ b/src/web/frontend/src/common/config.js
@@ -1,2 +1,2 @@
-export const API_URL = 'http://localhost:5000/api'
+export const API_URL = '/api'
 export default API_URL


### PR DESCRIPTION
When the web app runs on different port than 5000 or on a remote server, it will try to reach the API endpoint, but without success.
@danil-topc I am not sure that this is the proper fix (although it works). Could you please check it out?