### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import os
+import setuptools
+
+SETUPDIR = os.path.dirname(__file__)
+
+with open(os.path.join(SETUPDIR, 'README.md'), 'r') as f:
+    long_description = f.read()
+
+PKGNAME = "teap"
+packages = [f"{PKGNAME}"]
+
+for p in setuptools.find_packages(where="src/web", exclude=["tests"]):
+    packages.append(f"{PKGNAME}.{p}")
+
+setuptools.setup(
+    name='teap',
+    version='0.0.1',
+    author='EnterpriseyIntranet',
+    description="Integration of LDAP and Nextcloud, Rocketchat",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/EnterpriseyIntranet/teap",
+    packages=packages,
+    package_dir={"teap": "src/web"},
+    include_package_data=True,
+    classifiers=[
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: GNU General Public License (GPL)',
+        "Operating System :: OS Independent",
+    ],
+)

--- a/src/web/.dockerignore
+++ b/src/web/.dockerignore
@@ -1,1 +1,3 @@
 .env
+venv
+frontend/node_modules

--- a/src/web/__init__.py
+++ b/src/web/__init__.py
@@ -1,0 +1,1 @@
+from . import backend

--- a/src/web/backend/app.py
+++ b/src/web/backend/app.py
@@ -1,8 +1,8 @@
 """The app module, containing the app factory function."""
 from flask import Flask, render_template
 
-from backend import commands, public, user, core, nextcloud, rocket_chat, ldap
-from backend.extensions import bcrypt, cache, db, login_manager, migrate
+from . import commands, public, user, core, nextcloud, rocket_chat, ldap
+from .extensions import bcrypt, cache, db, login_manager, migrate
 
 
 def create_app(config_object='backend.settings'):

--- a/src/web/backend/ldap/api.py
+++ b/src/web/backend/ldap/api.py
@@ -2,7 +2,7 @@ from flask import Blueprint, jsonify, request
 from flask.views import MethodView
 from edap import ObjectDoesNotExist, ConstraintError, MultipleObjectsFound
 
-from backend.utils import EncoderWithBytes
+from ..utils import EncoderWithBytes
 from .serializers import edap_user_schema, edap_users_schema, edap_franchise_schema, edap_franchises_schema, \
     edap_divisions_schema, edap_teams_schema, edap_division_schema
 from .api_serializers import api_franchise_schema, api_user_schema, api_users_schema, api_franchises_schema, \

--- a/src/web/backend/ldap/models.py
+++ b/src/web/backend/ldap/models.py
@@ -3,8 +3,8 @@ from edap import ObjectDoesNotExist, ConstraintError
 from nextcloud.base import Permission as NxcPermission
 
 from .utils import EdapMixin, get_edap
-from backend.nextcloud.utils import get_nextcloud, get_group_folder, create_group_folder
-from backend.rocket_chat.utils import rocket_service
+from ..nextcloud.utils import get_nextcloud, get_group_folder, create_group_folder
+from ..rocket_chat.utils import rocket_service
 
 # TODO: separate layer with edap from data models
 

--- a/src/web/backend/nextcloud/api.py
+++ b/src/web/backend/nextcloud/api.py
@@ -3,8 +3,8 @@ from flask.views import MethodView
 
 from edap import ConstraintError, MultipleObjectsFound, ObjectDoesNotExist
 
-from backend.utils import EncoderWithBytes
-from backend.ldap.utils import EdapMixin
+from ..utils import EncoderWithBytes
+from ..ldap.utils import EdapMixin
 
 from .utils import create_group_folder, get_nextcloud
 

--- a/src/web/backend/public/forms.py
+++ b/src/web/backend/public/forms.py
@@ -3,7 +3,7 @@ from flask_wtf import FlaskForm
 from wtforms import PasswordField, StringField
 from wtforms.validators import DataRequired
 
-from backend.user.models import User
+from ..user.models import User
 
 
 class LoginForm(FlaskForm):

--- a/src/web/backend/public/views.py
+++ b/src/web/backend/public/views.py
@@ -2,8 +2,8 @@
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_login import login_user, logout_user, login_required
 
-from backend.public.forms import LoginForm
-from backend.utils import flash_errors
+from ..public.forms import LoginForm
+from ..utils import flash_errors
 
 blueprint = Blueprint('public', __name__, template_folder='./templates')
 

--- a/src/web/backend/rocket_chat/api.py
+++ b/src/web/backend/rocket_chat/api.py
@@ -3,7 +3,7 @@ from flask.views import MethodView
 
 from edap import ObjectDoesNotExist
 
-from backend.ldap.utils import EdapMixin
+from ..ldap.utils import EdapMixin
 
 from .utils import get_rocket, RocketMixin, rocket_service
 
@@ -83,7 +83,7 @@ class UserTeamsChatsViewSet(RocketMixin, EdapMixin, MethodView):
 
     def post(self, uid, team_machine_name):
         """ Add user to team chats """
-        from backend.ldap.serializers import edap_team_schema
+        from ..ldap.serializers import edap_team_schema
         team = edap_team_schema.load(self.edap.get_team(team_machine_name)).data
         try:
             franchise, division = team.get_team_components()

--- a/src/web/backend/rocket_chat/utils.py
+++ b/src/web/backend/rocket_chat/utils.py
@@ -2,7 +2,7 @@ from flask import g
 
 from rocketchat_API.rocketchat import RocketChat
 
-from backend.settings import ROCKETCHAT_HOST, ROCKETCHAT_PASSWORD, ROCKETCHAT_USER
+from ..settings import ROCKETCHAT_HOST, ROCKETCHAT_PASSWORD, ROCKETCHAT_USER
 
 
 def get_rocket():

--- a/src/web/backend/user/models.py
+++ b/src/web/backend/user/models.py
@@ -3,8 +3,8 @@ import datetime as dt
 
 from flask_login import UserMixin
 
-from backend.database import Column, Model, SurrogatePK, db, reference_col, relationship
-from backend.extensions import bcrypt
+from ..database import Column, Model, SurrogatePK, db, reference_col, relationship
+from ..extensions import bcrypt
 
 
 class Role(SurrogatePK, Model):


### PR DESCRIPTION
This PR introduces the minimal `setup.py`, which defines (and is capable of installing) the `teap.backend` package.
The rest of the code has been changed to use relative imports, while it should continue to work.