### PR TITLE
Updated code to work with new marshmallow.

### DIFF
--- a/src/web/backend/ldap/serializers.py
+++ b/src/web/backend/ldap/serializers.py
@@ -23,8 +23,9 @@ class BaseLdapSchema(Schema):
         return data
 
     @pre_load
-    def pre_load_unpack(self, data):
+    def pre_load_unpack(self, data, ** kwargs):
         """ Unpack data """
+        assert not kwargs.get("many"), "We expect to unpack only one-by-one"
         return self.unpack_data(data)
 
     def dump(self, *args, **kwargs):


### PR DESCRIPTION
As of `3.0.0`, `partial` and `many` are always passed as keyword arguments to the decorated method.