### PR TITLE
Flexibility improvement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(SETUPDIR, 'README.md'), 'r') as f:
 PKGNAME = "teap"
 packages = [f"{PKGNAME}"]
 
-for p in setuptools.find_packages(where="src/web", exclude=["tests"]):
+for p in setuptools.find_packages(where="src/web/backend", exclude=["tests"]):
     packages.append(f"{PKGNAME}.{p}")
 
 setuptools.setup(
@@ -21,7 +21,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/EnterpriseyIntranet/teap",
     packages=packages,
-    package_dir={"teap": "src/web"},
+    package_dir={"teap": "src/web/backend"},
     include_package_data=True,
     classifiers=[
         'Programming Language :: Python :: 3.6',

--- a/src/web/backend/actions/models.py
+++ b/src/web/backend/actions/models.py
@@ -57,13 +57,13 @@ class ActionABC:
             return self._execute_rocket()
 
     def _execute_rocket(self):
-        from backend.rocket_chat.utils import rocket_service
+        from ..rocket_chat import utils as rutils
         if self.event_name == self.CREATE_ROCKET_USER:
-            return rocket_service.create_user(**self.data)
+            return rutils.rocket_service.create_user(**self.data)
         elif self.event_name == self.CREATE_ROCKET_CHANNEL:
-            return rocket_service.create_channel(**self.data)
+            return rutils.rocket_service.create_channel(**self.data)
         elif self.event_name == self.INVITE_USER_TO_CHANNEL:
-            return rocket_service.invite_user_to_channel(**self.data)
+            return rutils.rocket_service.invite_user_to_channel(**self.data)
 
 
 class Action(SurrogatePK, Model, ActionABC):

--- a/src/web/backend/app.py
+++ b/src/web/backend/app.py
@@ -18,14 +18,21 @@ def create_app(config_object='backend.settings'):
     register_errorhandlers(app)
     register_shellcontext(app)
     register_commands(app)
+    initialize_modules(app)
     return app
+
+
+def initialize_modules(app):
+    rocket_chat.initialize_module(app)
+    return None
 
 
 def register_extensions(app):
     """Register Flask extensions."""
-    db.init_app(app)
+    if not app.config["SQLALCHEMY_DATABASE_URI"]:
+        db.init_app(app)
+        migrate.init_app(app, db)
     login_manager.init_app(app)
-    migrate.init_app(app, db)
     return None
 
 

--- a/src/web/backend/ldap/models.py
+++ b/src/web/backend/ldap/models.py
@@ -4,7 +4,7 @@ from nextcloud.base import Permission as NxcPermission
 
 from .utils import EdapMixin, get_edap
 from ..nextcloud.utils import get_nextcloud, get_group_folder, flush_nextcloud_ldap_cache
-from ..rocket_chat.utils import rocket_service, sanitize_room_name
+from ..rocket_chat import utils as rutils
 
 # TODO: separate layer with edap from data models
 NEXTCLOUD_ADMIN_GROUP = "admin"
@@ -22,7 +22,7 @@ class GroupChatMixin:
         Create channel in chat
         Returns (dict):
         """
-        channel_res = rocket_service.create_channel(channel_name=self.chat_name)
+        channel_res = rutils.rocket_service.create_channel(channel_name=self.chat_name)
         return channel_res.json()
 
     def channel_exists(self):
@@ -30,7 +30,7 @@ class GroupChatMixin:
         Check if franchise channel in chat exists
         Returns (bool):
         """
-        return bool(rocket_service.get_channel_by_name(self.chat_name))
+        return bool(rutils.rocket_service.get_channel_by_name(self.chat_name))
 
 
 class GroupFolderMixin:
@@ -129,14 +129,14 @@ class LdapUser(EdapMixin, User):
         Returns (tuple):
             (success (bool), data (dict))
         """
-        rocket_res = rocket_service.create_user(username=self.uid, password=password, email=self.mail, name=self.given_name)
+        rocket_res = rutils.rocket_service.create_user(username=self.uid, password=password, email=self.mail, name=self.given_name)
         return rocket_res.json()
 
     def delete_chat_account(self):
         """ Delete user's chat account """
-        rocket_user = rocket_service.get_user_by_username(self.uid)
+        rocket_user = rutils.rocket_service.get_user_by_username(self.uid)
         if rocket_user and rocket_user.get('_id'):
-            return rocket_service.delete_user(rocket_user['_id'])
+            return rutils.rocket_service.delete_user(rocket_user['_id'])
 
     def get_teams(self):
         """ Get teams where user is a member """
@@ -197,7 +197,7 @@ class Franchise(GroupChatMixin, GroupFolderMixin):
 
     @property
     def chat_name(self):
-        return sanitize_room_name(f'Franchise-{self.display_name}')
+        return rutils.sanitize_room_name(f'Franchise-{self.display_name}')
 
     @property
     def folder_path(self):
@@ -342,7 +342,7 @@ class Division(GroupChatMixin, GroupFolderMixin):
 
     @property
     def chat_name(self):
-        return sanitize_room_name(f'Division-{self.display_name}')
+        return rutils.sanitize_room_name(f'Division-{self.display_name}')
 
     @property
     def folder_path(self):

--- a/src/web/backend/nextcloud/utils.py
+++ b/src/web/backend/nextcloud/utils.py
@@ -42,7 +42,7 @@ def get_group_folder(mount_point):
 
 def check_consistency():
     """ Check if all required system objects exist in Edap """
-    from backend.ldap.models import Franchise, Division
+    from ..ldap.models import Franchise, Division
     nxc = get_nextcloud()
 
     main_franchises_folder_id = get_group_folder(Franchise.GROUP_FOLDER)

--- a/src/web/backend/rocket_chat/__init__.py
+++ b/src/web/backend/rocket_chat/__init__.py
@@ -1,1 +1,10 @@
 from . import api
+
+
+def register_blueprint(app):
+    app.register_blueprint(api.blueprint)
+
+
+def initialize_module(app):
+    from . import utils
+    utils.populate_service(app.config["SQLALCHEMY_DATABASE_URI"])

--- a/src/web/backend/rocket_chat/utils.py
+++ b/src/web/backend/rocket_chat/utils.py
@@ -65,7 +65,6 @@ def log_rocket_action(event_name):
 
 class RocketChatService(RocketMixin):
 
-    @log_rocket_action(event_name=Action.CREATE_ROCKET_USER)
     def create_user(self, username, password, email, name):
         """
         Create user
@@ -81,7 +80,6 @@ class RocketChatService(RocketMixin):
         """
         return self.rocket.users_create(email, name, password, username, requirePasswordChange=True)
 
-    @log_rocket_action(event_name=Action.CREATE_ROCKET_CHANNEL)
     def create_channel(self, channel_name):
         """
         Create channel
@@ -93,7 +91,6 @@ class RocketChatService(RocketMixin):
         """
         return self.rocket.channels_create(channel_name)
 
-    @log_rocket_action(event_name=Action.INVITE_USER_TO_CHANNEL)
     def invite_user_to_channel(self, rocket_channel, rocket_user):
         return self.rocket.channels_invite(rocket_channel, rocket_user)
 
@@ -122,4 +119,26 @@ class RocketChatService(RocketMixin):
         return users[0]
 
 
-rocket_service = RocketChatService()
+class LoggingRocketChatService(RocketChatService):
+    @log_rocket_action(event_name=Action.CREATE_ROCKET_USER)
+    def create_user(self, username, password, email, name):
+        return super().create_user(username, password, email, name)
+
+    @log_rocket_action(event_name=Action.CREATE_ROCKET_CHANNEL)
+    def create_channel(self, channel_name):
+        return super().create_channel(channel_name)
+
+    @log_rocket_action(event_name=Action.INVITE_USER_TO_CHANNEL)
+    def invite_user_to_channel(self, rocket_channel, rocket_user):
+        return super().invite_user_to_channel(rocket_channel, rocket_user)
+
+
+def populate_service(logging_enabled):
+    global rocket_service
+    if logging_enabled:
+        rocket_service = LoggingRocketChatService()
+    else:
+        rocket_service = RocketChatService()
+
+
+rocket_service = None

--- a/src/web/backend/settings.py
+++ b/src/web/backend/settings.py
@@ -13,7 +13,7 @@ env.read_env()
 ENV = env.str('FLASK_ENV', default='production')
 DEBUG = ENV == 'development'
 
-SQLALCHEMY_DATABASE_URI = env.str('DATABASE_URL')
+SQLALCHEMY_DATABASE_URI = env.str('DATABASE_URL', default="")
 SECRET_KEY = env.str('SECRET_KEY')
 BCRYPT_LOG_ROUNDS = env.int('BCRYPT_LOG_ROUNDS', default=13)
 DEBUG_TB_ENABLED = DEBUG


### PR DESCRIPTION
- Don't use the DB tools if the DB URL is not specified (e.g. if TEAP is not used standalone)
- Rewrite the setup so it installs the backend as `teap` package, and no init file in `web` is needed.